### PR TITLE
Bugfix/faro 30

### DIFF
--- a/Example/Tests/CallSpec.swift
+++ b/Example/Tests/CallSpec.swift
@@ -179,8 +179,13 @@ class CallSpec: QuickSpec {
                                                               "a number": 123])
                 expect(data).to(beNil())
             }
+            
+            it("should not produce invalid URL's when given malformed parameters") {
+                let parameters = [String: String]()
+                let callString: String = componentString(type: .urlComponents, parameters: parameters)
+                expect(callString.characters.last) != "?"
+            }
         }
-        
     }
 
 }

--- a/Example/Tests/CallSpec.swift
+++ b/Example/Tests/CallSpec.swift
@@ -180,8 +180,20 @@ class CallSpec: QuickSpec {
                 expect(data).to(beNil())
             }
             
-            it("should not produce invalid URL's when given malformed parameters") {
+            it("should not produce invalid URL's when given empty parameters") {
                 let parameters = [String: String]()
+                let callString: String = componentString(type: .urlComponents, parameters: parameters)
+                expect(callString.characters.last) != "?"
+            }
+            
+            it("should not produce invalid URL's when given parameters with missing keys") {
+                let parameters = ["" : "aValue"]
+                let callString: String = componentString(type: .urlComponents, parameters: parameters)
+                expect(callString.characters.last) != "?"
+            }
+            
+            it("should not produce invalid URL's when given parameters with missing values") {
+                let parameters = ["aKey" : ""]
                 let callString: String = componentString(type: .urlComponents, parameters: parameters)
                 expect(callString.characters.last) != "?"
             }

--- a/Sources/Parameters.swift
+++ b/Sources/Parameters.swift
@@ -6,9 +6,23 @@ public struct Parameters {
     public init?(type: ParameterType, parameters: [String: Any]) {
         switch type {
         case .urlComponents:
-            guard let _ = parameters as? [String: String] else {
+            guard let params = parameters as? [String: String] else {
                 printFaroError(FaroError.malformed(info: "url components should be only Strings"))
                 return nil
+            }
+            if (params.isEmpty) {
+                printFaroError(FaroError.malformed(info: "url components can not be empty"))
+                return nil
+            }
+            for (key, value) in params {
+                if (key.isEmpty) {
+                    printFaroError(FaroError.malformed(info: "key for value \"" + value + "\" can not be empty"))
+                    return nil
+                }
+                if (value.isEmpty) {
+                    printFaroError(FaroError.malformed(info: "value for key \"" + key + "\" can not be empty"))
+                    return nil
+                }
             }
         default:
             break


### PR DESCRIPTION
Adds checks on URL query component parameters so users can not create invalid URL's by passing malformed dictionaries.
