### PR TITLE
Feature/authorization retry

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,19 @@
+excluded:
+  - ./Pods
+
+disabled_rules:
+  - variable_name
+  - type_name
+  - implicit_getter
+  - void_return
+  - closure_parameter_position
+  - trailing_whitespace
+
+line_length:
+  - 180
+
+function_body_length:
+  - 200
+
+large_tuple:
+  - 4

--- a/Example/Faro.xcodeproj/project.pbxproj
+++ b/Example/Faro.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		C0ACDE651D79B65A00064801 /* MockModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0ACDE631D79B65100064801 /* MockModel.swift */; };
 		C0BFD2C01D90E1D200FAB4E0 /* SerializableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BFD2BE1D90E09900FAB4E0 /* SerializableSpec.swift */; };
 		C0C3D4DE1D8EA01F0011E972 /* DeserializationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C3D4DD1D8EA01F0011E972 /* DeserializationSpec.swift */; };
+		C0D9E9231E6D7197003972DD /* FaroSecureURLSessionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D9E9221E6D7197003972DD /* FaroSecureURLSessionSpec.swift */; };
 		C0ECD8AF1DAE2ADF00ECC8E8 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		D377DE1E7E23BDD451F1AF77 /* Pods_Faro_Example_Faro_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81E1A5D1778B1450F795E6D9 /* Pods_Faro_Example_Faro_Tests.framework */; };
 /* End PBXBuildFile section */
@@ -91,6 +92,7 @@
 		C0ACDE631D79B65100064801 /* MockModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockModel.swift; sourceTree = "<group>"; };
 		C0BFD2BE1D90E09900FAB4E0 /* SerializableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SerializableSpec.swift; sourceTree = "<group>"; };
 		C0C3D4DD1D8EA01F0011E972 /* DeserializationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeserializationSpec.swift; sourceTree = "<group>"; };
+		C0D9E9221E6D7197003972DD /* FaroSecureURLSessionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FaroSecureURLSessionSpec.swift; path = Tests/FaroSecureURLSessionSpec.swift; sourceTree = SOURCE_ROOT; };
 		D39D515CDEB600C0DEBE26E0 /* Pods-Faro_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Faro_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Faro_Example/Pods-Faro_Example.release.xcconfig"; sourceTree = "<group>"; };
 		DBBD94A15C031D6EAFAF4B10 /* Pods-Faro_Example-Faro_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Faro_Example-Faro_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Faro_Example-Faro_Tests/Pods-Faro_Example-Faro_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		F28FE425E9CA20CB4C7DE52F /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
@@ -273,6 +275,7 @@
 		C05EBF701D4B8E3000B950EB /* Faro_Tests */ = {
 			isa = PBXGroup;
 			children = (
+				C0D9E9221E6D7197003972DD /* FaroSecureURLSessionSpec.swift */,
 				C05EBF731D4B8E3000B950EB /* Info.plist */,
 			);
 			path = Faro_Tests;
@@ -524,6 +527,7 @@
 				C02ADF831D88243A00FA5B32 /* ServiceSpec.swift in Sources */,
 				C00C1D291D9D8D51002D43B7 /* MockServiceSpec.swift in Sources */,
 				C02ADF821D88243A00FA5B32 /* CallSpec.swift in Sources */,
+				C0D9E9231E6D7197003972DD /* FaroSecureURLSessionSpec.swift in Sources */,
 				C03FB1501DE365D900B14A15 /* ServiceQueueSpec.swift in Sources */,
 				B599F5421D9A9EB400C2BCD4 /* FaroServiceSpec.swift in Sources */,
 				C0ACDE651D79B65A00064801 /* MockModel.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		C03E70E31E6966F7000D03A8 /* FaroURLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C03E70C81E6966F7000D03A8 /* FaroURLSessionDelegate.swift */; };
 		C0914006B6EBC93EF9ACC5027578A61D /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327117A1FDD7C2FF6C1AF66DED8EB802 /* ExampleGroup.swift */; };
 		C0D9E91F1E6D63CD003972DD /* Authorizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D9E91E1E6D63CD003972DD /* Authorizable.swift */; };
+		C0D9E9211E6D6AE6003972DD /* HTTPURLResponseRetyable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D9E9201E6D6AE6003972DD /* HTTPURLResponseRetyable.swift */; };
 		C137125F78B5EA8778AD38FCB3F8605C /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6FB7E38EC9AC2254A89EF721D9D3731 /* AssertionDispatcher.swift */; };
 		C23D6CB3B46A61D1E0164FB3263E111C /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F47FB710808C923F90EA50F6F90E98 /* BeLessThanOrEqual.swift */; };
 		C5022C12EC4D7DEDA9A3B0E8B7FBB39E /* Print.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D9BBEE76B66C128C9D69DA3EC04161 /* Print.swift */; };
@@ -327,6 +328,7 @@
 		C03E70C81E6966F7000D03A8 /* FaroURLSessionDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FaroURLSessionDelegate.swift; sourceTree = "<group>"; };
 		C0B769D1B9C229AE6E5B6169327BA744 /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
 		C0D9E91E1E6D63CD003972DD /* Authorizable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Authorizable.swift; sourceTree = "<group>"; };
+		C0D9E9201E6D6AE6003972DD /* HTTPURLResponseRetyable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPURLResponseRetyable.swift; sourceTree = "<group>"; };
 		C20D34449F185BBF0B84BA08C3450E6F /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
 		C6FB7E38EC9AC2254A89EF721D9D3731 /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
 		C9BCD7F3B3A13C40ADF85E8B42694FFD /* FailureMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FailureMessage.swift; path = Sources/Nimble/FailureMessage.swift; sourceTree = "<group>"; };
@@ -760,6 +762,7 @@
 				C03E70C61E6966F7000D03A8 /* FaroSession.swift */,
 				C03E70C71E6966F7000D03A8 /* FaroSessionable.swift */,
 				C08EF7EC1E696843006B9EC9 /* URLSessionDelegate */,
+				C0D9E9201E6D6AE6003972DD /* HTTPURLResponseRetyable.swift */,
 			);
 			name = URLSession;
 			path = Sources/URLSession;
@@ -1075,6 +1078,7 @@
 				C03E70D51E6966F7000D03A8 /* Configuration.swift in Sources */,
 				C03E70E01E6966F7000D03A8 /* FaroSecureURLSession.swift in Sources */,
 				C03E70D91E6966F7000D03A8 /* FaroService.swift in Sources */,
+				C0D9E9211E6D6AE6003972DD /* HTTPURLResponseRetyable.swift in Sources */,
 				C03E70DD1E6966F7000D03A8 /* ServiceQueue.swift in Sources */,
 				C03E70DC1E6966F7000D03A8 /* ServiceConvenienceExtension.swift in Sources */,
 				C03E70E31E6966F7000D03A8 /* FaroURLSessionDelegate.swift in Sources */,

--- a/Example/Tests/FaroSecureURLSessionSpec.swift
+++ b/Example/Tests/FaroSecureURLSessionSpec.swift
@@ -54,7 +54,7 @@ class FaroSecureURLSessionSpec: QuickSpec {
 				httpResponse =  HTTPURLResponse(url: testRequest.url!, statusCode: 401, httpVersion:nil, headerFields: nil)!
 			}
 
-			fit("should retry and count") {
+			it("should retry and count") {
 
 				expect(session.shouldRetry(httpResponse)) == true
 				expect(session.retryCountTuples.map {$0.count}) == []

--- a/Example/Tests/FaroSecureURLSessionSpec.swift
+++ b/Example/Tests/FaroSecureURLSessionSpec.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+import Quick
+import Nimble
+
+import Faro
+@testable import Faro_Example
+
+class RetryFaroSecureURLSession: FaroSecureURLSession, HTTPURLResponseRetryable {
+
+	var retryCount: Int = 0
+
+	func shouldRetry(_ response: HTTPURLResponse) -> Bool {
+		return true
+	}
+
+	func makeRequestValidforRetry(_ request: inout URLRequest, after httpResponse: HTTPURLResponse, retryCount: Int) throws {
+		self.retryCount = retryCount
+	}
+
+}
+
+class FaroSecureURLSessionSpec: QuickSpec {
+
+	override func spec() {
+
+		describe("Keep track of the retry count") {
+
+			var session: RetryFaroSecureURLSession!
+			var testRequest: URLRequest!
+			var httpResponse: HTTPURLResponse!
+
+			beforeEach {
+				session = RetryFaroSecureURLSession(urlSessionDelegate: FaroURLSessionDelegate(allowUntrustedCertificates: false))
+				testRequest = URLRequest(url: URL(string: "http://www.google.com")!)
+				httpResponse =  HTTPURLResponse(url: testRequest.url!, statusCode: 401, httpVersion:nil, headerFields: nil)!
+			}
+
+			it("should retry and count") {
+
+				expect(session.shouldRetry(httpResponse)) == true
+				expect(session.retryCount) == 0
+
+				var variableRequest = testRequest
+
+				try? session.makeRequestValidforRetry(&variableRequest!, after: httpResponse, retryCount: session.retryCount(for: testRequest))
+
+				expect(session.retryCount) == 1
+			}
+
+			it("count should increase a second time") {
+				var variableRequest = testRequest
+
+				try? session.makeRequestValidforRetry(&variableRequest!, after: httpResponse, retryCount: session.retryCount(for: testRequest))
+				try? session.makeRequestValidforRetry(&variableRequest!, after: httpResponse, retryCount: session.retryCount(for: testRequest))
+
+				expect(session.retryCount) == 2
+			}
+
+		}
+		
+	}
+
+}

--- a/Example/Tests/FaroSecureURLSessionSpec.swift
+++ b/Example/Tests/FaroSecureURLSessionSpec.swift
@@ -12,12 +12,12 @@ class RetryFaroSecureURLSession: FaroSecureURLSession, HTTPURLResponseRetryable 
 		return true
 	}
 
-	func makeRequestValidforRetry(failedRequest: inout URLRequest,
+	func makeRequestValidforRetry(failedRequest: URLRequest,
 	                              after httpResponse: HTTPURLResponse,
 	                              retryCount: Int,
-	                              requestForRetry: @escaping (inout URLRequest) -> Void,
+	                              requestForRetry: @escaping (URLRequest) -> Void,
 	                              noRetryNeeded: @escaping (FaroError?) -> Void) {
-		requestForRetry(&failedRequest)
+		requestForRetry(failedRequest)
 	}
 
 }
@@ -28,10 +28,10 @@ enum RetryError: Error {
 
 class RetryStoppedFaroSecureURLSession: RetryFaroSecureURLSession {
 
-	override func makeRequestValidforRetry(failedRequest: inout URLRequest,
+	override func makeRequestValidforRetry(failedRequest: URLRequest,
 	                                       after httpResponse: HTTPURLResponse,
 	                                       retryCount: Int,
-	                                       requestForRetry: @escaping (inout URLRequest) -> Void,
+	                                       requestForRetry: @escaping (URLRequest) -> Void,
 	                                       noRetryNeeded: @escaping (FaroError?) -> Void) {
 		noRetryNeeded(nil)
 	}
@@ -45,13 +45,13 @@ class FaroSecureURLSessionSpec: QuickSpec {
 		describe("Keep track of the retry count") {
 
 			var session: RetryFaroSecureURLSession!
-			var testRequest: URLRequest?
+			var testRequest: URLRequest!
 			var httpResponse: HTTPURLResponse!
 
 			beforeEach {
 				session = RetryFaroSecureURLSession(urlSessionDelegate: FaroURLSessionDelegate(allowUntrustedCertificates: false))
 				testRequest = URLRequest(url: URL(string: "http://www.google.com")!)
-				httpResponse =  HTTPURLResponse(url: testRequest!.url!, statusCode: 401, httpVersion:nil, headerFields: nil)!
+				httpResponse =  HTTPURLResponse(url: testRequest.url!, statusCode: 401, httpVersion:nil, headerFields: nil)!
 			}
 
 			fit("should retry and count") {
@@ -59,7 +59,7 @@ class FaroSecureURLSessionSpec: QuickSpec {
 				expect(session.shouldRetry(httpResponse)) == true
 				expect(session.retryCountTuples.map {$0.count}) == []
 
-				session.handleRetry(data: nil, httpResponse: httpResponse, for: &testRequest!, completionHandler: {(_, _, _) in }, task: { (_) in
+				session.handleRetry(data: nil, httpResponse: httpResponse, for: testRequest, completionHandler: {(_, _, _) in }, task: { (_) in
 				}, noRetryNeeded: {_ in})
 
 				expect(session.retryCountTuples.map {$0.count}) == [1]
@@ -67,7 +67,7 @@ class FaroSecureURLSessionSpec: QuickSpec {
 
 			context("has tried once") {
 				beforeEach {
-					session.handleRetry(data: nil, httpResponse: httpResponse, for: &testRequest!, completionHandler: {(_, _, _) in }, task: { (task) in
+					session.handleRetry(data: nil, httpResponse: httpResponse, for: testRequest, completionHandler: {(_, _, _) in }, task: { (task) in
 					}, noRetryNeeded: { (_) in
 					})
 
@@ -75,7 +75,7 @@ class FaroSecureURLSessionSpec: QuickSpec {
 				}
 
 				it("count should increase a second time") {
-					session.handleRetry(data: nil, httpResponse: httpResponse, for: &testRequest!, completionHandler: {(_, _, _) in }, task: { (task) in
+					session.handleRetry(data: nil, httpResponse: httpResponse, for: testRequest, completionHandler: {(_, _, _) in }, task: { (task) in
 					}, noRetryNeeded: { (_) in
 					})
 
@@ -83,17 +83,17 @@ class FaroSecureURLSessionSpec: QuickSpec {
 				}
 
 				it("removes request from retryCount when finished") {
-					session.handleEnding(for: &testRequest!)
+					session.handleEnding(for: testRequest)
 
 					expect(session.retryCountTuples.map {$0.count}) == []
 				}
 
 				it("still contains other retry counts after one is stopped") {
-					session.retryCountTuples.append((hashValue: 169, count: 10))
+					session.retryCountTuples.append((requestIdentifier: "169", count: 10))
 
-					session.handleEnding(for: &testRequest!)
+					session.handleEnding(for: testRequest)
 
-					expect(session.retryCountTuples.map {$0.hashValue}) == [169]
+					expect(session.retryCountTuples.map {$0.requestIdentifier}) == ["169"]
 				}
 
 			}
@@ -102,33 +102,33 @@ class FaroSecureURLSessionSpec: QuickSpec {
 
 		describe("Stop retrying") {
 			var session: RetryStoppedFaroSecureURLSession!
-			var testRequest: URLRequest?
+			var testRequest: URLRequest!
 			var httpResponse: HTTPURLResponse!
 
 			beforeEach {
 				session = RetryStoppedFaroSecureURLSession(urlSessionDelegate: FaroURLSessionDelegate(allowUntrustedCertificates: false))
 				testRequest = URLRequest(url: URL(string: "http://www.google.com")!)
-				session.retryCountTuples.append((hashValue: testRequest!.hashValue, count: 1))
-				httpResponse =  HTTPURLResponse(url: testRequest!.url!, statusCode: 401, httpVersion:nil, headerFields: nil)!
+				session.retryCountTuples.append((requestIdentifier: testRequest.requestIdentifier, count: 1))
+				httpResponse =  HTTPURLResponse(url: testRequest.url!, statusCode: 401, httpVersion:nil, headerFields: nil)!
 			}
 
 			it("has request in retry") {
-				expect(session.retryCountTuples.map {$0.hashValue}) == [testRequest!.hashValue]
+				expect(session.retryCountTuples.map {$0.requestIdentifier}) == [testRequest.requestIdentifier]
 			}
 
 			it("removes request when stopped") {
-				session.handleEnding(for: &testRequest!)
-				expect(session.retryCountTuples.map {$0.hashValue}) == []
+				session.handleEnding(for: testRequest)
+				expect(session.retryCountTuples.map {$0.requestIdentifier}) == []
 			}
 
 			it("still contains other retry counts after one is stopped") {
-				session.retryCountTuples.append((hashValue: 169, count: 10))
+				session.retryCountTuples.append((requestIdentifier: "169", count: 10))
 
-				session.handleRetry(data: nil, httpResponse: httpResponse, for: &testRequest!, completionHandler: {(_, _, _) in }, task: { (task) in
+				session.handleRetry(data: nil, httpResponse: httpResponse, for: testRequest, completionHandler: {(_, _, _) in }, task: { (task) in
 				}, noRetryNeeded: { (_) in
 				})
 
-				expect(session.retryCountTuples.map {$0.hashValue}) == [169]
+				expect(session.retryCountTuples.map {$0.requestIdentifier}) == ["169"]
 			}
 
 		}

--- a/Example/Tests/FaroSecureURLSessionSpec.swift
+++ b/Example/Tests/FaroSecureURLSessionSpec.swift
@@ -12,7 +12,12 @@ class RetryFaroSecureURLSession: FaroSecureURLSession, HTTPURLResponseRetryable 
 		return true
 	}
 
-	func makeRequestValidforRetry(_ request: inout URLRequest, after httpResponse: HTTPURLResponse, retryCount: Int) throws {
+	func makeRequestValidforRetry(failedRequest: inout URLRequest,
+	                              after httpResponse: HTTPURLResponse,
+	                              retryCount: Int,
+	                              requestForRetry: @escaping (inout URLRequest) -> Void,
+	                              noRetryNeeded: @escaping (FaroError?) -> Void) {
+		requestForRetry(&failedRequest)
 	}
 
 }
@@ -23,8 +28,12 @@ enum RetryError: Error {
 
 class RetryStoppedFaroSecureURLSession: RetryFaroSecureURLSession {
 
-	override func makeRequestValidforRetry(_ request: inout URLRequest, after httpResponse: HTTPURLResponse, retryCount: Int) throws {
-		throw RetryError.stop
+	override func makeRequestValidforRetry(failedRequest: inout URLRequest,
+	                                       after httpResponse: HTTPURLResponse,
+	                                       retryCount: Int,
+	                                       requestForRetry: @escaping (inout URLRequest) -> Void,
+	                                       noRetryNeeded: @escaping (FaroError?) -> Void) {
+		noRetryNeeded(nil)
 	}
 
 }
@@ -36,42 +45,45 @@ class FaroSecureURLSessionSpec: QuickSpec {
 		describe("Keep track of the retry count") {
 
 			var session: RetryFaroSecureURLSession!
-			var testRequest: URLRequest!
+			var testRequest: URLRequest?
 			var httpResponse: HTTPURLResponse!
 
 			beforeEach {
 				session = RetryFaroSecureURLSession(urlSessionDelegate: FaroURLSessionDelegate(allowUntrustedCertificates: false))
 				testRequest = URLRequest(url: URL(string: "http://www.google.com")!)
-				httpResponse =  HTTPURLResponse(url: testRequest.url!, statusCode: 401, httpVersion:nil, headerFields: nil)!
+				httpResponse =  HTTPURLResponse(url: testRequest!.url!, statusCode: 401, httpVersion:nil, headerFields: nil)!
 			}
 
-			it("should retry and count") {
+			fit("should retry and count") {
 
 				expect(session.shouldRetry(httpResponse)) == true
 				expect(session.retryCountTuples.map {$0.count}) == []
 
-				var variableRequest = testRequest
-
-				try? session.makeRequestValidforRetry(&variableRequest!, after: httpResponse, retryCount: session.retryCount(for: testRequest))
+				session.handleRetry(data: nil, httpResponse: httpResponse, for: &testRequest!, completionHandler: {(_, _, _) in }, task: { (_) in
+				}, noRetryNeeded: {_ in})
 
 				expect(session.retryCountTuples.map {$0.count}) == [1]
 			}
 
 			context("has tried once") {
 				beforeEach {
-					let _ = session.handleRetry(data:nil, httpResponse: httpResponse, for: testRequest, completionHandler: {(_, _, _) in })
+					session.handleRetry(data: nil, httpResponse: httpResponse, for: &testRequest!, completionHandler: {(_, _, _) in }, task: { (task) in
+					}, noRetryNeeded: { (_) in
+					})
 
 					expect(session.retryCountTuples.map {$0.count}) == [1]
 				}
 
 				it("count should increase a second time") {
-					let _ = session.handleRetry(data:nil, httpResponse: httpResponse, for: testRequest, completionHandler: {(_, _, _) in })
+					session.handleRetry(data: nil, httpResponse: httpResponse, for: &testRequest!, completionHandler: {(_, _, _) in }, task: { (task) in
+					}, noRetryNeeded: { (_) in
+					})
 
 					expect(session.retryCountTuples.map {$0.count}) == [2]
 				}
 
 				it("removes request from retryCount when finished") {
-					session.handleEnding(for: testRequest)
+					session.handleEnding(for: &testRequest!)
 
 					expect(session.retryCountTuples.map {$0.count}) == []
 				}
@@ -79,7 +91,7 @@ class FaroSecureURLSessionSpec: QuickSpec {
 				it("still contains other retry counts after one is stopped") {
 					session.retryCountTuples.append((hashValue: 169, count: 10))
 
-					session.handleEnding(for: testRequest)
+					session.handleEnding(for: &testRequest!)
 
 					expect(session.retryCountTuples.map {$0.hashValue}) == [169]
 				}
@@ -90,29 +102,31 @@ class FaroSecureURLSessionSpec: QuickSpec {
 
 		describe("Stop retrying") {
 			var session: RetryStoppedFaroSecureURLSession!
-			var testRequest: URLRequest!
+			var testRequest: URLRequest?
 			var httpResponse: HTTPURLResponse!
 
 			beforeEach {
 				session = RetryStoppedFaroSecureURLSession(urlSessionDelegate: FaroURLSessionDelegate(allowUntrustedCertificates: false))
 				testRequest = URLRequest(url: URL(string: "http://www.google.com")!)
-				session.retryCountTuples.append((hashValue: testRequest.hashValue, count: 1))
-				httpResponse =  HTTPURLResponse(url: testRequest.url!, statusCode: 401, httpVersion:nil, headerFields: nil)!
+				session.retryCountTuples.append((hashValue: testRequest!.hashValue, count: 1))
+				httpResponse =  HTTPURLResponse(url: testRequest!.url!, statusCode: 401, httpVersion:nil, headerFields: nil)!
 			}
 
 			it("has request in retry") {
-				expect(session.retryCountTuples.map {$0.hashValue}) == [testRequest.hashValue]
+				expect(session.retryCountTuples.map {$0.hashValue}) == [testRequest!.hashValue]
 			}
 
 			it("removes request when stopped") {
-				session.handleEnding(for: testRequest)
+				session.handleEnding(for: &testRequest!)
 				expect(session.retryCountTuples.map {$0.hashValue}) == []
 			}
 
 			it("still contains other retry counts after one is stopped") {
 				session.retryCountTuples.append((hashValue: 169, count: 10))
 
-				let _ = session.handleRetry(data: nil, httpResponse: httpResponse, for: testRequest, completionHandler: { (_, _, _) in})
+				session.handleRetry(data: nil, httpResponse: httpResponse, for: &testRequest!, completionHandler: {(_, _, _) in }, task: { (task) in
+				}, noRetryNeeded: { (_) in
+				})
 
 				expect(session.retryCountTuples.map {$0.hashValue}) == [169]
 			}

--- a/Example/Tests/FaroSecureURLSessionSpec.swift
+++ b/Example/Tests/FaroSecureURLSessionSpec.swift
@@ -3,7 +3,7 @@ import Foundation
 import Quick
 import Nimble
 
-import Faro
+@testable import Faro
 @testable import Faro_Example
 
 class RetryFaroSecureURLSession: FaroSecureURLSession, HTTPURLResponseRetryable {
@@ -49,10 +49,8 @@ class FaroSecureURLSessionSpec: QuickSpec {
 			}
 
 			it("count should increase a second time") {
-				var variableRequest = testRequest
-
-				try? session.makeRequestValidforRetry(&variableRequest!, after: httpResponse, retryCount: session.retryCount(for: testRequest))
-				try? session.makeRequestValidforRetry(&variableRequest!, after: httpResponse, retryCount: session.retryCount(for: testRequest))
+				let _ = session.handleRetry(data:nil, httpResponse: httpResponse, for: testRequest, completionHandler: {(_, _, _) in })
+				let _ = session.handleRetry(data:nil, httpResponse: httpResponse, for: testRequest, completionHandler: {(_, _, _) in })
 
 				expect(session.retryCount) == 2
 			}

--- a/Sources/URLSession/FaroSecureURLSession.swift
+++ b/Sources/URLSession/FaroSecureURLSession.swift
@@ -27,6 +27,7 @@ open class FaroSecureURLSession: NSObject, FaroSessionable {
 
 			guard let responseRetryableSelf = self as? HTTPURLResponseRetryable else {
 				print("❓ \(self) can implement '\(Faro.HTTPURLResponseRetryable)' and react to specific responses for any task handeld by \(self).")
+				completionHandler(data, response, error)
 				return
 			}
 

--- a/Sources/URLSession/FaroSecureURLSession.swift
+++ b/Sources/URLSession/FaroSecureURLSession.swift
@@ -6,7 +6,7 @@ open class FaroSecureURLSession: NSObject, FaroSessionable {
 
 	public let session: URLSession
 
-	lazy var retryCountTuples: [(hashValue: Int, count: Int)] = [(hashValue: Int, count: Int)]()
+	lazy var retryCountTuples: [(requestIdentifier: String, count: Int)] = [(requestIdentifier: String, count: Int)]()
 
 	public init(_ configuration: URLSessionConfiguration = URLSessionConfiguration.default, urlSessionDelegate: FaroURLSessionDelegate, delegateQueue: OperationQueue? = nil ) {
 		session = URLSession(configuration: configuration, delegate: urlSessionDelegate, delegateQueue: delegateQueue)
@@ -15,6 +15,7 @@ open class FaroSecureURLSession: NSObject, FaroSessionable {
 
 	/// For any response that is a 'HTTPURLResponse` this function checks if self implements `HTTPURLResponseRetryable`. 
 	/// If implemented the a task can be retried with a latered request as explained in the protocol.
+	/// Faro extends 'URLRequest' with 'URLRequestRetryable'. It has a default implementation to identify request between retries. You can change this if it is not enough.
 	open func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void) -> URLSessionDataTask {
 
 		var task: URLSessionDataTask!
@@ -38,18 +39,18 @@ open class FaroSecureURLSession: NSObject, FaroSessionable {
 					completionHandler(data, response, error)
 					return
 				}
-				self.handleRetry(data: data, httpResponse: httpResponse, for: &request, completionHandler: completionHandler, task: { (task) in
+				self.handleRetry(data: data, httpResponse: httpResponse, for: request, completionHandler: completionHandler, task: { (fixedTask) in
 					self.resume(task)
 				}, noRetryNeeded: { (faroError) in
 					completionHandler(data, httpResponse, faroError)
 				})
 
 			} else {
-				guard var request = task.originalRequest else {
+				guard let request = task.originalRequest else {
 					completionHandler(data, response, error)
 					return
 				}
-				self.handleEnding(for: &request)
+				self.handleEnding(for: request)
 				completionHandler(data, response, error)
 			}
 
@@ -64,52 +65,48 @@ open class FaroSecureURLSession: NSObject, FaroSessionable {
 
 	// MARK: - Retry count
 
-	public func retryCount(for request: inout URLRequest) -> Int {
-		guard let countTuple = (retryCountTuples.first {$0.hashValue == request.hashValue}) else {
-			plusRetryCount(for: &request)
+	public func retryCount(for request: URLRequest) -> Int {
+		guard let countTuple = (retryCountTuples.first {$0.requestIdentifier == request.requestIdentifier}) else {
+			plusRetryCount(for: request)
 			return 1
 		}
 		return countTuple.count
 	}
 
-	func handleEnding(for request: inout URLRequest) {
-		removeFromRetryCount(for: &request)
+	func handleEnding(for request: URLRequest) {
+		removeFromRetryCount(for: request)
 	}
 
-	func handleRetry(data:Data?, httpResponse: HTTPURLResponse, for request: inout URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void, task: @escaping (URLSessionDataTask) -> Void, noRetryNeeded: @escaping (FaroError?) -> Void) {
+	func handleRetry(data:Data?, httpResponse: HTTPURLResponse, for request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void, task: @escaping (URLSessionDataTask) -> Void, noRetryNeeded: @escaping (FaroError?) -> Void) {
 		guard let responseRetryableSelf = self as? HTTPURLResponseRetryable else {
 			print("❓ \(self) can implement '\(Faro.HTTPURLResponseRetryable)' and react to specific responses for any task handeld by \(self).")
 			noRetryNeeded(nil)
 			return
 		}
 
-		self.plusRetryCount(for: &request)
-		let requestHashValue = request.hashValue
-		responseRetryableSelf.makeRequestValidforRetry(failedRequest: &request, after: httpResponse, retryCount: retryCount(for: &request), requestForRetry: { (requestForRetry) in
+		self.plusRetryCount(for: request)
+		responseRetryableSelf.makeRequestValidforRetry(failedRequest: request, after: httpResponse, retryCount: retryCount(for: request), requestForRetry: { (requestForRetry) in
 			task(self.dataTask(with: requestForRetry, completionHandler: completionHandler))
 		}, noRetryNeeded: {(error) in
-			self.removeFromRetryCount(hashValue: requestHashValue)
+			self.removeFromRetryCount(for: request)
 			noRetryNeeded(error)
 		})
 	}
 	
-	private func plusRetryCount(for request: inout URLRequest) {
-		if let currentCount = (retryCountTuples.enumerated().first {$0.element.hashValue == request.hashValue}) {
+	private func plusRetryCount(for request: URLRequest) {
+		if let currentCount = (retryCountTuples.enumerated().first {$0.element.requestIdentifier == request.requestIdentifier}) {
 			retryCountTuples.remove(at: currentCount.offset)
-			retryCountTuples.insert((hashValue: request.hashValue, count: currentCount.element.count + 1), at: currentCount.offset)
+			retryCountTuples.insert((requestIdentifier: request.requestIdentifier, count: currentCount.element.count + 1), at: currentCount.offset)
 		} else {
-			retryCountTuples.append((hashValue: request.hashValue, count: 1))
+			retryCountTuples.append((requestIdentifier: request.requestIdentifier, count: 1))
 		}
 	}
 
-	private func removeFromRetryCount(for request: inout URLRequest) {
-		removeFromRetryCount(hashValue: request.hashValue)
-	}
-
-	private func removeFromRetryCount(hashValue: Int) {
-		if let currentCount = (retryCountTuples.enumerated().first {$0.element.hashValue == hashValue}) {
+	private func removeFromRetryCount(for request: URLRequest) {
+		if let currentCount = (retryCountTuples.enumerated().first {$0.element.requestIdentifier == request.requestIdentifier}) {
 			retryCountTuples.remove(at: currentCount.offset)
 		}
 	}
+
 	
 }

--- a/Sources/URLSession/FaroSecureURLSession.swift
+++ b/Sources/URLSession/FaroSecureURLSession.swift
@@ -35,7 +35,7 @@ open class FaroSecureURLSession: NSObject, FaroSessionable {
 			// In case the session is ResponseRetryable the task can be retried with an updated request.
 
 			if responseRetryableSelf.shouldRetry(httpResponse) {
-				guard var request = task.originalRequest else {
+				guard let request = task.originalRequest else {
 					completionHandler(data, response, error)
 					return
 				}

--- a/Sources/URLSession/FaroSecureURLSession.swift
+++ b/Sources/URLSession/FaroSecureURLSession.swift
@@ -1,13 +1,5 @@
 import Foundation
 
-open class FaroURLSessionConfiguration {
-	let allowUntrustedCertificates: Bool
-
-	public init(allowUntrustedCertificates: Bool) {
-		self.allowUntrustedCertificates = allowUntrustedCertificates
-	}
-}
-
 /// Handles delegate calls from 'URLSessionDelegate' and uses 'FaroURLSessionConfiguration to do a few common use cases. 
 /// Faro also works with your own URLSession but you can use this as a convenience
 open class FaroSecureURLSession: NSObject, FaroSessionable {

--- a/Sources/URLSession/FaroSecureURLSession.swift
+++ b/Sources/URLSession/FaroSecureURLSession.swift
@@ -55,7 +55,7 @@ open class FaroSecureURLSession: NSObject, FaroSessionable {
 					completionHandler(data, response, error)
 					return
 				}
-
+				self.handleEnding(for: request)
 				completionHandler(data, response, error)
 			}
 
@@ -78,7 +78,7 @@ open class FaroSecureURLSession: NSObject, FaroSessionable {
 		return countTuple.count
 	}
 
-	func handleEding(for request: URLRequest) {
+	func handleEnding(for request: URLRequest) {
 		removeFromRetryCount(for: request)
 	}
 
@@ -95,6 +95,7 @@ open class FaroSecureURLSession: NSObject, FaroSessionable {
 			return self.dataTask(with: variableRequest, completionHandler: completionHandler)
 		} catch let thrownError {
 			print("\(self) stopping retry after \(thrownError)")
+			removeFromRetryCount(for: request)
 			completionHandler(data, httpResponse, thrownError)
 			return nil
 		}

--- a/Sources/URLSession/FaroSecureURLSession.swift
+++ b/Sources/URLSession/FaroSecureURLSession.swift
@@ -40,7 +40,7 @@ open class FaroSecureURLSession: NSObject, FaroSessionable {
 					return
 				}
 				self.handleRetry(data: data, httpResponse: httpResponse, for: request, completionHandler: completionHandler, task: { (fixedTask) in
-					self.resume(task)
+					self.resume(fixedTask)
 				}, noRetryNeeded: { (faroError) in
 					completionHandler(data, httpResponse, faroError)
 				})

--- a/Sources/URLSession/FaroSecureURLSession.swift
+++ b/Sources/URLSession/FaroSecureURLSession.swift
@@ -13,7 +13,8 @@ open class FaroSecureURLSession: NSObject, FaroSessionable {
 		super.init()
 	}
 
-	///
+	/// For any response that is a 'HTTPURLResponse` this function checks if self implements `HTTPURLResponseRetryable`. 
+	/// If implemented the a task can be retried with a latered request as explained in the protocol.
 	open func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Swift.Void) -> URLSessionDataTask {
 
 		var task: URLSessionDataTask!

--- a/Sources/URLSession/FaroURLSessionDelegate.swift
+++ b/Sources/URLSession/FaroURLSessionDelegate.swift
@@ -10,16 +10,24 @@ import Foundation
 
 open class FaroURLSessionDelegate: NSObject, URLSessionDelegate {
 
-	let challengeFunction: (_ challenge: URLAuthenticationChallenge, _ completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void
+	public let allowUntrustedCertificates: Bool
 
-	public init(_ challenge: @escaping (_ challenge: URLAuthenticationChallenge, _ completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) {
-		self.challengeFunction = challenge
+	public init(allowUntrustedCertificates: Bool) {
+		self.allowUntrustedCertificates = allowUntrustedCertificates
 		super.init()
 	}
 
 	//swiftlint:disable line_length
 	open func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-		self.challengeFunction(challenge, completionHandler)
+
+		if allowUntrustedCertificates {
+			if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
+				guard let trust  =  challenge.protectionSpace.serverTrust else {
+					return
+				}
+				completionHandler(.useCredential, URLCredential(trust:trust))
+			}
+		}
 	}
-	
+
 }

--- a/Sources/URLSession/HTTPURLResponseRetyable.swift
+++ b/Sources/URLSession/HTTPURLResponseRetyable.swift
@@ -19,6 +19,6 @@ public protocol HTTPURLResponseRetryable {
 	/// - parameter request: the request to make valid again
 	/// - parameter httpResponse: the received response
 	/// - parameter retryCount: the amount of times we asked the implementer of HTTPURLResponseRetryable to retry the request. If this is to high throw any error to stop.
-	func makeRequestValidforRetry(_ request: inout URLRequest, after httpResponse: HTTPURLResponse, retryCount: Int) throws
+	func makeRequestValidforRetry(failedRequest: inout URLRequest, after httpResponse: HTTPURLResponse, retryCount: Int, requestForRetry: @escaping (inout URLRequest) -> Void, noRetryNeeded: @escaping (FaroError?) -> Void)
 
 }

--- a/Sources/URLSession/HTTPURLResponseRetyable.swift
+++ b/Sources/URLSession/HTTPURLResponseRetyable.swift
@@ -1,0 +1,24 @@
+//
+//  ResponseRetryable.swift
+//  Pods
+//
+//  Created by Stijn Willems on 06/03/2017.
+//
+//
+
+import Foundation
+
+public protocol HTTPURLResponseRetryable {
+
+	func shouldRetry(_ response: HTTPURLResponse) -> Bool
+
+	/// Make the request valid again based on the response
+	/// If it is not possible you can throw any error and it will be printed.
+	/// After throwing the original data, response, error will be send to the completion handler
+	/// If not thrown a new URLSessionDataTask is made and given to the URLSession to be handled.
+	/// - parameter request: the request to make valid again
+	/// - parameter httpResponse: the received response
+	/// - parameter retryCount: the amount of times we asked the implementer of HTTPURLResponseRetryable to retry the request. If this is to high throw any error to stop.
+	func makeRequestValidforRetry(_ request: inout URLRequest, after httpResponse: HTTPURLResponse, retryCount: Int) throws
+
+}

--- a/Sources/URLSession/HTTPURLResponseRetyable.swift
+++ b/Sources/URLSession/HTTPURLResponseRetyable.swift
@@ -16,9 +16,21 @@ public protocol HTTPURLResponseRetryable {
 	/// If it is not possible you can throw any error and it will be printed.
 	/// After throwing the original data, response, error will be send to the completion handler
 	/// If not thrown a new URLSessionDataTask is made and given to the URLSession to be handled.
-	/// - parameter request: the request to make valid again
+	/// - parameter request: the request to make valid again. Faro extends 'URLRequest' with 'URLRequestRetryable'. If this is not enough for your request use URLRequest's with your own implementation of 'URLRequestRetryable'
 	/// - parameter httpResponse: the received response
 	/// - parameter retryCount: the amount of times we asked the implementer of HTTPURLResponseRetryable to retry the request. If this is to high throw any error to stop.
-	func makeRequestValidforRetry(failedRequest: inout URLRequest, after httpResponse: HTTPURLResponse, retryCount: Int, requestForRetry: @escaping (inout URLRequest) -> Void, noRetryNeeded: @escaping (FaroError?) -> Void)
+	func makeRequestValidforRetry(failedRequest: URLRequest, after httpResponse: HTTPURLResponse, retryCount: Int, requestForRetry: @escaping (URLRequest) -> Void, noRetryNeeded: @escaping (FaroError?) -> Void)
 
+}
+
+/// To identify requests that can be retried
+public protocol URLRequestRetryable {
+	var requestIdentifier: String {get}
+}
+
+extension URLRequest: URLRequestRetryable {
+
+	public var requestIdentifier: String {
+		return "\(self.httpMethod) \(self.url) \(self.httpBody)"
+	}
 }


### PR DESCRIPTION
Het komt vrij vaak voor dat bij 401 de request opnieuw gedaan moet worden. Daarom heb ik dit centraal bij de URLSession laten afhandelen.

Waarom doe ik nu zo moeilijk over een retryCount?

Als die er niet is en de session handelt meer dan 1 taak af. Dan kan een simpele var count niet want voor welke task wordt er dan geteld. Zou kunnend at dit nog eenvoudiger kan maar dan hoor ik het graag.

Waarom een FaroUrlSession en niet gewoon een subclass van URLSession. Dit is om redenen van het testbaar te krijgen. Ook dit kan misschien eenvoudiger maar dit is wat ik vond.